### PR TITLE
feature:Automatic restart after failure

### DIFF
--- a/Start_Qsign.bat
+++ b/Start_Qsign.bat
@@ -141,9 +141,9 @@ if %errorlevel% equ 0 (
 ) else (
     echo Qsign API is not running, Restarting...
     if defined pid (
-      tasklist /fi "PID eq %pid%" | findstr /i "%pid%" >nul
+      tasklist /fi "PID eq !pid!" | findstr /i "!pid!" >nul
         if %errorlevel% equ 0 (
-          askkill /F /PID %pid%))
+          askkill /F /PID !pid!))
     start "Qsign-Onekey" cmd /c "bin\unidbg-fetch-qsign --basePath=%library%%txlib_version%"
     timeout /t 15 /nobreak >nul
     for /f "tokens=5" %%A in ('netstat -ano ^| findstr ":!port!.*LISTENING"') do (

--- a/Start_Qsign.bat
+++ b/Start_Qsign.bat
@@ -131,4 +131,23 @@ echo Qsign_version:%ver%
 echo TXlib_version:%txlib_version% 
 echo -------------------------------------------------------------------------------------------------
 timeout /t 3 > nul
-bin\unidbg-fetch-qsign --basePath=%library%%txlib_version%
+
+:loop
+curl -I http://!host!:!port!/register?uin=12345678 >nul 2>nul
+if %errorlevel% equ 0 (
+    echo Qsign API is running.
+    timeout /t 30 /nobreak >nul
+    goto loop
+) else (
+    echo Qsign API is not running, Restarting...
+    if defined pid (
+      tasklist /fi "PID eq %pid%" | findstr /i "%pid%" >nul
+        if %errorlevel% equ 0 (
+          askkill /F /PID %pid%))
+    start "Qsign-Onekey" cmd /c "bin\unidbg-fetch-qsign --basePath=%library%%txlib_version%"
+    timeout /t 15 /nobreak >nul
+    for /f "tokens=5" %%A in ('netstat -ano ^| findstr ":!port!.*LISTENING"') do (
+      set "pid=%%A")
+    echo Qsign API running on processes with PID:!pid!.
+    goto loop
+)


### PR DESCRIPTION
尝试解决了 https://github.com/rhwong/qsign-onekey/issues/3

使用了 https://github.com/rhwong/qsign-onekey/issues/3#issuecomment-1666702845 提供的进程监测方法；
qsign启动时稍等，用netstat方式获取进程pid暂存，每隔30s循环请求api的qq实例注册接口来判断qsign进程是否正常，若异常则根据pid杀掉进程重新拉起一个新的qsign

效果如图
![cf6f5227aa29cf8833d5562e7f946157](https://github.com/rhwong/qsign-onekey/assets/73411104/81b2d7e9-6480-412b-874f-1c68fcd31337)
